### PR TITLE
adding apptainer/singularity definition file based on latest docker

### DIFF
--- a/pathml.def
+++ b/pathml.def
@@ -1,0 +1,61 @@
+Bootstrap: docker
+From: nvidia/cuda:11.8.0-devel-ubuntu22.04
+
+%labels
+    Maintainer Chun Kiet Vong
+    Version 0.2.0
+
+%files
+    setup.py /opt/pathml/
+    README.md /opt/pathml
+    pathml/ /opt/pathml/pathml
+    tests/ /opt/pathml/tests
+
+%environment
+    export PATH="/opt/miniconda3/bin:${PATH}"
+    export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre/"
+
+%post
+    export DEBIAN_FRONTEND=noninteractive
+    
+    apt-get update && apt-get install -y --no-install-recommends \
+        openslide-tools \
+        g++ \
+        gcc  \
+        libpixman-1-0 \
+        libblas-dev \
+        liblapack-dev \
+        wget \
+        openjdk-8-jre \
+        openjdk-8-jdk \
+        apt-utils \
+        git \
+        software-properties-common
+
+    wget https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh &&\
+        bash Miniconda3-py38_4.10.3-Linux-x86_64.sh -bfp /opt/miniconda3/ && \
+        rm -f Miniconda3-py38_4.10.3-Linux-x86_64.sh && \
+        rm -rf /var/lib/apt/lists/*
+
+    mkdir /var/inputdata
+    mkdir /var/outputdata
+    
+    # conda and pip install prerequisites (last line installs segmentation_models)
+    export PATH="/opt/miniconda3/bin:${PATH}"
+    conda install -y -c anaconda cudatoolkit=11.0 && \
+        conda install -y -c intel mpi4py && \
+        conda install -y -c conda-forge dask-mpi && \
+        pip3 install pip==21.3.1 && \
+        pip3 install numpy==1.19.5 spams==2.6.2.5 imutils && \
+        pip3 install python-bioformats==4.0.0 scipy scikit-image matplotlib Cython imgaug ipykernel openslide-python tqdm deepcell pytest && \
+        pip3 install /opt/pathml/ && \
+        pip3 install git+https://github.com/qubvel/segmentation_models.pytorch && \
+        pip3 install -U albumentations && \
+        pip3 install fastnumbers && \
+        pip3 install bokeh==2.4.3 && \
+        pip3 install pytorch-lightning
+
+    pip3 install jupyter -U && pip3 install jupyterlab
+
+    NOW=`date`
+    echo "export NOW=\"${NOW}\"" >> $APPTAINER_ENVIRONMENT


### PR DESCRIPTION
Hi Chun, this can be built on NeSI using a command like:

```
module purge
module load Apptainer

export APPTAINER_CACHEDIR=/nesi/nobackup/uoa03709/apptainer_cache
export APPTAINER_TMPDIR=/nesi/nobackup/uoa03709/apptainer_tmpdir
mkdir -p $APPTAINER_CACHEDIR $APPTAINER_TMPDIR
setfacl -b $APPTAINER_TMPDIR

sbatch --time=2:00:00 --ntasks=1 --mem=8G --partition=milan --wrap "env --unset=TMPDIR apptainer build --fakeroot --force pathml.sif pathml.def"
```

The above command will build the container inside a Slurm job. You can check the job is running using `squeue --me` and the output should be written to a file called "slurm-<jobid>.out" where <jobid> will be the job id of the slurm job.

More documentation here: https://support.nesi.org.nz/hc/en-gb/articles/6008779241999-Build-an-Apptainer-container-on-a-Mahuika-Extension-Node